### PR TITLE
Enhanced mapping and module info

### DIFF
--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -15,6 +15,7 @@ OSC'elot is a mapping module for OSC controllers based on stoermelder's MIDI-CAT
   + [Map an entire module](#map-an-entire-module)
   + [Map parameters one at a time](#map-parameters-one-at-a-time)
 * [MeowMory](#meowmory)
+* [MeowMemory](#meowmemory)
 * [Context-Label](#context-label)
 * [Menu Options](#menu-options)
   + [Additional features](#additional-features)
@@ -135,6 +136,35 @@ Modules without a mapping will be skipped. This can also be triggered via OSC:
 ![MeowMory workflow2](./Oscelot-scan.gif)
 
 <br/>
+
+---
+## MeowMemory
+OSC'elot can save and broadcast an arbitrary string value sent from a connected OSC client (which will be saved in OSC'elot module presets etc).  
+
+This allows a connected OSC client application to use OSC'elot as a brain to remember and retrieve information related to the current VCVrack patch (e.g. layout of controls for specific mapped modules).
+
+### Save client state in OSC'elot
+
+Send from client to OSC'elot:
+`/oscelot/storestate, args: ('Some stringified state') `
+
+| Name          | Type      | Value         | Notes                                     |
+| ------------- |:---------:|:-------------:|-------------------------------------------|
+| State         | String   | `'<some arbitrary string>'`   | Client state string        |      
+
+### Retrieve client state from OSC'elot
+
+Send a request message to OSC'elot:
+`/oscelot/getstate`  (no args)
+
+OSC'elot wil respond with a `/state` message:
+`/state, args: ('<stored client state string>')`
+
+| Name          | Type      | Value         | Notes                                     |
+| ------------- |:---------:|:-------------:|-------------------------------------------|
+| State         | String   | `'<some arbitrary string>'`   | Client state string        |  
+
+<br />
 
 ---
 ## Context-Label

--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -55,7 +55,7 @@ For a fader mapped to a MixMaster Volume fader:
 
 > Sent from OSC'elot:  
 `/fader, args: (1, 0.3499999940395355)`  
-`/fader/info, args: (1, 'MixMaster', '-01-: level', '-21.335', ' dB')`
+`/fader/info, args: (1, 'MixMaster', '-01-: level', '-21.335', ' dB', 'MixMaster')`
 
 For an encoder mapped to a MixMaster Pan knob:  
 > Sent from controller:  
@@ -74,6 +74,8 @@ The second message ending with `/info` has the integer Id arg followed by info a
 | Label         | String    | `'-01-: pan'` | Not affected by OSC'elot labels           |
 | DisplayValue  | String    | `'4.6225'`    | Value shown when for param in VCV         |
 | Unit          | String    | `'%'`         | Blank string if param does not have units |
+| ModuleSlug    | String    | `'MixMaster'` | Unique module name                        |
+
 
 <br/>
 
@@ -86,7 +88,7 @@ A typical workflow for mapping your controller will look like this:
 
 <br/>
 
-### Map an entire module  
+### Map an entire module
 This option changes your cursor into a crosshair which needs to be pointed onto any module within your patch by clicking on the panel.
   - *`Clear first`* clears OSC mappings before mapping new module. **SHORTCUT** `Ctrl/Cmd+Shift+D`
   - *`Keep OSC assignments`* keeps the OSC mappings and re-maps them onto the new module. **SHORTCUT** `Shift+D`
@@ -95,7 +97,7 @@ This option changes your cursor into a crosshair which needs to be pointed onto 
 
 <br/>
 
-### Map parameters one at a time  
+### Map parameters one at a time
 - Activate the first mapping slot by clicking on it.
 - Click on a parameter of any module in your patch. The slot will bind this parameter.
 - Touch a control or key on your OSC device. The slot will bind the OSC message.

--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -140,12 +140,15 @@ Both messages take an optional argument, which can be either a module name or a 
 OSC'elot can provide list of modules with saved mappings in the current Rack, triggered via OSC:
 > `/oscelot/listmodules`  
 
-OSC'elot will send a `/oscelot/moduleList` message with a series of 2 arguments, one argumenrt pair per Rack module with a OSC'elot mapping.
+OSC'elot will send a `/oscelot/moduleList` message with a series of arguments, one argument set per Rack module with a OSC'elot mapping.
 
 | Name          | Type      | Value         | Notes                                     |
 | ------------- |:---------:|:-------------:|-------------------------------------------|
 | key            | String   | `'VultModules UtilKnobs'` | the internal meowMoryStorage key for the module mapping, which can be sent back to OSC'elot in a `/oscelot/next` message to switch to that module  |
 | moduleName     | String   | `'Knobs'` | Module display name  |
+| y              | Float    | `38000`   | Module widget y position |
+| x              | Float    | `31110`   | Module widget x position |
+
 
 <br/>
 

--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -124,6 +124,14 @@ A typical workflow will look like this:
 Stored module-mappings can be recalled by using the middle `Apply` button or hotkey `Shift+V` while hovering OSC'elot.  
 The cursor changes to a crosshair and the saved OSC-mapping is loaded into OSC'elot after you click on a module in your patch.  
 
+This can also be done by sending a `oscelot/select` OSC message with arguments of the x and y module widget positions in the Rack
+
+| Name          | Type      | Value         | Notes                                     |
+| ------------- |:---------:|:-------------:|-------------------------------------------|
+| y              | Float    | `38000`   | Module widget y position |
+| x              | Float    | `31110`   | Module widget x position |
+
+
 ![MeowMory workflow1](./Oscelot-Meowmory.gif)
 
 <br/>

--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -133,7 +133,19 @@ Modules without a mapping will be skipped. This can also be triggered via OSC:
 > `/oscelot/next`  
 > `/oscelot/prev`  
 
+Both messages take an optional argument, which can be either a module name or a meowMemoryStorage key.  OSC'elot will try and switch to the specified module, even if it is not in order.
+
 ![MeowMory workflow2](./Oscelot-scan.gif)
+
+OSC'elot can provide list of modules with saved mappings in the current Rack, triggered via OSC:
+> `/oscelot/listmodules`  
+
+OSC'elot will send a `/oscelot/moduleList` message with a series of 2 arguments, one argumenrt pair per Rack module with a OSC'elot mapping.
+
+| Name          | Type      | Value         | Notes                                     |
+| ------------- |:---------:|:-------------:|-------------------------------------------|
+| key            | String   | `'VultModules UtilKnobs'` | the internal meowMoryStorage key for the module mapping, which can be sent back to OSC'elot in a `/oscelot/next` message to switch to that module  |
+| moduleName     | String   | `'Knobs'` | Module display name  |
 
 <br/>
 

--- a/docs/Oscelot.md
+++ b/docs/Oscelot.md
@@ -145,10 +145,39 @@ Both messages take an optional argument, which can be either a module name or a 
 
 ![MeowMory workflow2](./Oscelot-scan.gif)
 
-OSC'elot can provide list of modules with saved mappings in the current Rack, triggered via OSC:
+
+When OSC'elot switches mapped modules, it will transmit a `/oscelot/moduleMeowMory/start` OSC message with details of the newly applied module BEFORE the individual parameter feedback messages.
+
+> Sent from OSC'elot:  
+`/oscelot/moduleMeowMory/start, args: ('neóni', 'Instruō neóni', 'Through-Zero Oscillator (neoni)', 13, 38380, 30045) `
+
+
+| Name               | Type      | Value         | Notes                                     |
+| ------------------ |:---------:|:-------------:|-------------------------------------------|
+| ModuleName         | String    | `'neóni'`    | Not affected by OSC'elot labels            |
+| ModuleLabel        | String    | `'Instruō neóni'`  | Module name shown VCV                |
+| Module description | String    | `'Through-Zero Oscillator (neoni)'` | Module description |
+| NumMappedParams    | Integer   | `13`      | Number of module parameters mapped in OSC'elot |
+| y                  | Float     | `38000`   | Module widget y position |
+| x                  | Float     | `31110`   | Module widget x position |
+
+
+Then, after OSC'elot has emitted current value and info messages for each mapped parameter, it transmits a `/oscelot/moduleMeowMory/end` OSC message 
+
+> Sent from OSC'elot:  
+`/oscelot/moduleMeowMory/end, args: (13) `
+
+| Name               | Type      | Value         | Notes                                     |
+| ------------------ |:---------:|:-------------:|-------------------------------------------|
+| NumMappedParams    | Integer   | `13`          | Number of module parameters mapped in OSC'elot |
+
+
+### listmodules request
+
+OSC'elot can also provide list of modules with saved mappings in the current Rack, triggered via an OSC request from the connected OSC client:
 > `/oscelot/listmodules`  
 
-OSC'elot will send a `/oscelot/moduleList` message with a series of arguments, one argument set per Rack module with a OSC'elot mapping.
+OSC'elot will respond with a `/oscelot/moduleList` message with a series of arguments, one argument set per Rack module with a OSC'elot mapping.
 
 | Name          | Type      | Value         | Notes                                     |
 | ------------- |:---------:|:-------------:|-------------------------------------------|
@@ -180,7 +209,7 @@ Send from client to OSC'elot:
 Send a request message to OSC'elot:
 `/oscelot/getstate`  (no args)
 
-OSC'elot wil respond with a `/state` message:
+OSC'elot will respond with a `/state` message:
 `/state, args: ('<stored client state string>')`
 
 | Name          | Type      | Value         | Notes                                     |

--- a/src/Oscelot.cpp
+++ b/src/Oscelot.cpp
@@ -920,6 +920,8 @@ struct OscelotModule : Module, OscelotExpanderBase {
         auto key = string::f("%s %s", m->model->plugin->slug.c_str(), m->model->slug.c_str());
         moduleListMessage.addStringArg(key);
  	      moduleListMessage.addStringArg(m->model->name);
+ 	      moduleListMessage.addFloatArg(mw->box.pos.y);
+ 	      moduleListMessage.addFloatArg(mw->box.pos.x);
 			}
 		}
     moduleListBundle.addMessage(moduleListMessage);

--- a/src/Oscelot.cpp
+++ b/src/Oscelot.cpp
@@ -71,11 +71,13 @@ struct OscelotModule : Module, OscelotExpanderBase {
 	int64_t meowMoryModuleId = -1;
 	std::string contextLabel = "";
 	std::string moduleSlug = "";
-
+	math::Vec modulePos;
+	
 	bool receiving;
 	bool sending;
 	bool oscTriggerNext;
 	bool oscTriggerPrev;
+	bool oscTriggerSelect;
 	bool oscReceived = false;
 	bool oscSent = false;
 
@@ -491,6 +493,12 @@ struct OscelotModule : Module, OscelotExpanderBase {
 				moduleSlug = msg.getArgAsString(0);
 			}
 			return oscReceived;
+		} else if (address == OSCMSG_SELECT_MODULE) {
+			oscTriggerSelect = true;
+			if (msg.getNumArgs() > 0) {
+				modulePos = Vec(msg.getArgAsFloat(1), msg.getArgAsFloat(0));
+			}
+			return oscReceived;	
 		} else if (address == OSCMSG_BANK_SELECT) {
 			int bankIndex = msg.getArgAsInt(0);
 			if (bankIndex >= 0 && bankIndex < 128) {

--- a/src/Oscelot.cpp
+++ b/src/Oscelot.cpp
@@ -716,7 +716,7 @@ struct OscelotModule : Module, OscelotExpanderBase {
 
 	void moduleMeowMoryDelete(std::string key) { meowMoryStorage.erase(key); }
 
-	void moduleMeowMoryApply(Module* m) {
+	void moduleMeowMoryApply(Module* m, math::Vec pos = Vec(0,0)) {
 		if (!m) return;
 		auto key = string::f("%s %s", m->model->plugin->slug.c_str(), m->model->slug.c_str());
 		auto it = meowMoryStorage.find(key);
@@ -729,6 +729,8 @@ struct OscelotModule : Module, OscelotExpanderBase {
 		startMessage.addStringArg(m->model->getFullName());
 		startMessage.addStringArg(m->model->description);
 		startMessage.addIntArg(meowMory.paramArray.size());
+		startMessage.addFloatArg(pos.y);
+		startMessage.addFloatArg(pos.x);
 		oscSender.sendMessage(startMessage);
 		sendEndMessage=1;
 

--- a/src/Oscelot.hpp
+++ b/src/Oscelot.hpp
@@ -16,9 +16,11 @@ static const std::string OSCMSG_MODULE_START = "/oscelot/moduleMeowMory/start";
 static const std::string OSCMSG_MODULE_END = "/oscelot/moduleMeowMory/end";
 static const std::string OSCMSG_BANK_START = "/oscelot/bankMeowMory/start";
 static const std::string OSCMSG_BANK_END = "/oscelot/bankMeowMory/end";
+static const std::string OSCMSG_MODULE_LIST = "/oscelot/moduleList";
 static const std::string OSCMSG_PREV_MODULE = "/oscelot/prev";
 static const std::string OSCMSG_NEXT_MODULE = "/oscelot/next";
 static const std::string OSCMSG_BANK_SELECT = "/oscelot/bank";
+static const std::string OSCMSG_LIST_MODULES = "/oscelot/listmodules";
 
 } // namespace Oscelot
 } // namespace TheModularMind

--- a/src/Oscelot.hpp
+++ b/src/Oscelot.hpp
@@ -19,6 +19,7 @@ static const std::string OSCMSG_BANK_END = "/oscelot/bankMeowMory/end";
 static const std::string OSCMSG_MODULE_LIST = "/oscelot/moduleList";
 static const std::string OSCMSG_PREV_MODULE = "/oscelot/prev";
 static const std::string OSCMSG_NEXT_MODULE = "/oscelot/next";
+static const std::string OSCMSG_SELECT_MODULE = "/oscelot/select";
 static const std::string OSCMSG_BANK_SELECT = "/oscelot/bank";
 static const std::string OSCMSG_LIST_MODULES = "/oscelot/listmodules";
 static const std::string OSCMSG_STORE_CLIENT_STATE = "/oscelot/storestate";

--- a/src/Oscelot.hpp
+++ b/src/Oscelot.hpp
@@ -21,6 +21,9 @@ static const std::string OSCMSG_PREV_MODULE = "/oscelot/prev";
 static const std::string OSCMSG_NEXT_MODULE = "/oscelot/next";
 static const std::string OSCMSG_BANK_SELECT = "/oscelot/bank";
 static const std::string OSCMSG_LIST_MODULES = "/oscelot/listmodules";
+static const std::string OSCMSG_STORE_CLIENT_STATE = "/oscelot/storestate";
+static const std::string OSCMSG_GET_CLIENT_STATE = "/oscelot/getstate";
+
 
 } // namespace Oscelot
 } // namespace TheModularMind

--- a/src/OscelotWidget.cpp
+++ b/src/OscelotWidget.cpp
@@ -324,12 +324,12 @@ struct OscelotWidget : ThemedModuleWidget<OscelotModule>, ParamWidgetContextExte
 					auto key = string::f("%s %s", m->model->plugin->slug.c_str(), m->model->slug.c_str());
 
 					if (m->model->slug.c_str() == moduleSlugName || key == moduleSlugName ) {
-						module->moduleMeowMoryApply(m);
+						module->moduleMeowMoryApply(m, mw->box.pos);
 						return;
 					} 
 					// if no name, get next saved mapping
 				} else {
-					module->moduleMeowMoryApply(m);
+					module->moduleMeowMoryApply(m, mw->box.pos);
 					return;
 				}
 			}
@@ -360,7 +360,7 @@ struct OscelotWidget : ThemedModuleWidget<OscelotModule>, ParamWidgetContextExte
 				Module* m = mw->module;
 			  if (module->moduleMeowMoryTest(m)) {
 			  	// If module at matched position is mapped in meowMory, we can safely apply its current mappings
-					module->moduleMeowMoryApply(m);
+					module->moduleMeowMoryApply(m, mw->box.pos);
 				}
 				return;
 			} 

--- a/src/OscelotWidget.cpp
+++ b/src/OscelotWidget.cpp
@@ -257,6 +257,12 @@ struct OscelotWidget : ThemedModuleWidget<OscelotModule>, ParamWidgetContextExte
 				module->moduleSlug = "";
 			}
 
+      if (module->oscTriggerSelect) {
+      	module->oscTriggerSelect = false;
+        meowMorySelectModule(module->modulePos);
+				module->modulePos = Vec(0,0);
+      }
+
 			if (meowMoryParamTrigger.process(module->params[OscelotModule::PARAM_APPLY].getValue())) {
 				enableLearn(LEARN_MODE::MEM);
 			}
@@ -334,6 +340,32 @@ struct OscelotWidget : ThemedModuleWidget<OscelotModule>, ParamWidgetContextExte
 			module->meowMoryModuleId = -1;
 			goto f;
 		}
+	}
+
+	void meowMorySelectModule(math::Vec modulePos) {
+		// Build mapped module list to scan through to 
+		std::list<Widget*> modules = APP->scene->rack->getModuleContainer()->children;
+		auto sort = [&](Widget* w1, Widget* w2) {
+			auto t1 = std::make_tuple(w1->box.pos.y, w1->box.pos.x);
+			auto t2 = std::make_tuple(w2->box.pos.y, w2->box.pos.x);
+			return t1 < t2;
+		};
+		modules.sort(sort);
+		std::list<Widget*>::iterator it = modules.begin();
+		
+		// Scan over all rack modules, find module at given rack position
+		for (; it != modules.end(); it++) {
+			ModuleWidget* mw = dynamic_cast<ModuleWidget*>(*it);
+			if (modulePos.equals(mw->box.pos)) {
+				Module* m = mw->module;
+			  if (module->moduleMeowMoryTest(m)) {
+			  	// If module at matched position is mapped in meowMory, we can safely apply its current mappings
+					module->moduleMeowMoryApply(m);
+				}
+				return;
+			} 
+		}
+
 	}
 
 	void extendParamWidgetContextMenu(ParamWidget* pw, Menu* menu) override {

--- a/src/OscelotWidget.cpp
+++ b/src/OscelotWidget.cpp
@@ -315,10 +315,12 @@ struct OscelotWidget : ThemedModuleWidget<OscelotModule>, ParamWidgetContextExte
 			if (module->moduleMeowMoryTest(m)) {
 				// Scan for module with name moduleSlug
 				if (moduleSlugName != "") {
-					if (m->model->slug.c_str() == moduleSlugName) {
+					auto key = string::f("%s %s", m->model->plugin->slug.c_str(), m->model->slug.c_str());
+
+					if (m->model->slug.c_str() == moduleSlugName || key == moduleSlugName ) {
 						module->moduleMeowMoryApply(m);
 						return;
-					}
+					} 
 					// if no name, get next saved mapping
 				} else {
 					module->moduleMeowMoryApply(m);


### PR DESCRIPTION
Set of additional OSC'elot changes to support advanced module mapping and interaction with connected OSC client applications (documented in oscelot.md):

1. Add module slug string to /fader/info messages
2. Allow client to store and retrieve arbitrary state (as a string) in OSC'elot state
3. Allow client to ask for a list of mapped modules and their current patch coordinate position in current VCVRack patch
4. Allow client to ask for OSC'elot to switch to any mapped module given a module co-ordinate position (equivalent to the Apply button + module select feature on the OSC'elot module panel)
5. Included mapped module coordinate position parameters on the new /oscelot/moduleMeowMory/start message
6. Updated documentation

These changes are necessary to support a TouchOSC template that can display a rack position - aware module navigator

<img width="682" alt="TouchOSCMappedModulesPage" src="https://github.com/The-Modular-Mind/oscelot/assets/678653/69ba9ec5-a407-412c-a4f6-02b67f1359d8">
